### PR TITLE
Add video type to object strategy and mapper helper

### DIFF
--- a/src/Divante/MagentoIntegrationBundle/Helper/MapperHelper.php
+++ b/src/Divante/MagentoIntegrationBundle/Helper/MapperHelper.php
@@ -23,7 +23,7 @@ class MapperHelper
     const BOOL_TYPES = ['booleanSelect', 'checkbox'];
     const SELECT_TYPES = ['select'];
     const QUANTITY_VALUE_TYPES = ['inputQuantityValue', 'quantityValue'];
-    const OBJECT_TYPES = ['href', 'image', 'manyToOneRelation', 'manyToOneObjectRelation'];
+    const OBJECT_TYPES = ['href', 'image', 'video', 'manyToOneRelation', 'manyToOneObjectRelation'];
     const MULTI_OBJECT_TYPES = [
         'multihref',
         'imageGallery',
@@ -34,6 +34,7 @@ class MapperHelper
     const STRUCTURED_TYPES = [self::LOCALIZED_FIELD_TYPE];
     const USER_TYPES = ['user'];
     const IMAGE_TYPES = ['image', 'imageGallery'];
+    const VIDEO_TYPES = ['video'];
     const MULTI_SELECT_TYPES = [
         'multiselect',
         'countrymultiselect',
@@ -48,3 +49,4 @@ class MapperHelper
     const OBJECT_BRICKS_TYPES        = [self::OBJECT_BRICKS_TYPE];
     const CLASSIFICATION_STORE_TYPES = [self::CLASSIFICATION_STORE_TYPE];
 }
+

--- a/src/Divante/MagentoIntegrationBundle/Mapper/Strategy/MapObjectValue.php
+++ b/src/Divante/MagentoIntegrationBundle/Mapper/Strategy/MapObjectValue.php
@@ -50,9 +50,17 @@ class MapObjectValue extends AbstractMapStrategy
         if ($field->value) {
             if (in_array($field->type, MapperHelper::IMAGE_TYPES)) {
                 return ['id' =>  $field->value, 'type' => 'asset'];
+            } elseif (in_array($field->type, MapperHelper::VIDEO_TYPES)) {
+                $video = unserialize($field->value);
+                return [
+                    'type' => 'video',
+                    'format' => $video['type'],
+                    'link' => $video['data']
+                ];
             } else {
                 return $field->value;
             }
         }
     }
 }
+


### PR DESCRIPTION
Added video element to entity message to be synced to Magento. Requires an update of the magento2-pimcore-bridge as well if you'd like to have video elements in your Magento project.